### PR TITLE
Change Dockerfile base because of repo migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerfile/java:oracle-java8
+FROM java:8
 MAINTAINER coderfi@gmail.com
 
 ENV AVRO_VERSION 1.7.7


### PR DESCRIPTION
This fixes error for people trying to build the Docker image locally.

See linked post for details: https://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/